### PR TITLE
service.py: Adjust incorrect empty value in start item

### DIFF
--- a/nose_reportportal/service.py
+++ b/nose_reportportal/service.py
@@ -113,7 +113,7 @@ class NoseServiceClass(with_metaclass(Singleton, object)):
             "tags": tags,
             "start_time": timestamp(),
             "item_type": "TEST",
-            "parameters": {},
+            "parameters": None,
         }
         self.post_log(name)
         return self.rp.start_test_item(**start_rq)

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -110,7 +110,7 @@ class NoseServiceClassTestCase(unittest.TestCase):
             tags=test.test.suites,
             start_time=mocked_timestamp(),
             item_type='TEST',
-            parameters={}
+            parameters=None
         ))
         expect(lambda: self.service.post_log.assert_called_once_with(name))
 


### PR DESCRIPTION
Start item is sent with an empty dictionary as parameters value which is
causing a bad request since the receiver expects a null-like value to
represent empty. This patch changes the value of parameters in the start
item event to be None instead of {}.